### PR TITLE
Hover Color for header set to white

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -17,7 +17,7 @@ a {
 a:hover,
 a:active,
 a:focus {
-  color: #1dc9ce;
+  color: #ffffff;
   outline: none;
   text-decoration: none;
 }


### PR DESCRIPTION
White when hovered is more visible, especially for the header menu towards the right as the background gradient is almost the same as the hover color.